### PR TITLE
[AWIT-130] dokończenie widoku z listą wszystkich wątków

### DIFF
--- a/frontend/src/components/Forum/FilterChips/ChipsStyle.tsx
+++ b/frontend/src/components/Forum/FilterChips/ChipsStyle.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export const ChipsButton = styled.button`
+    width: 100%;
+    min-height: 40px;
+    border: 3px solid #008F8C;
+    outline: none;
+    border-radius: 50px;
+    font-size: 17px;
+    padding: 5px;
+    color: #008F8C;
+    font-weight: bold;
+    text-align: center;
+  
+    &.active{
+      background-color: #008F8C;
+      color: white;
+    }
+`;

--- a/frontend/src/components/Forum/FilterChips/FilterChips.tsx
+++ b/frontend/src/components/Forum/FilterChips/FilterChips.tsx
@@ -1,0 +1,21 @@
+import React, {useRef} from "react";
+import {ChipsButton} from "./ChipsStyle";
+
+const FilterChips: React.FC<{text: string}> = ({text}) => {
+    const chips: React.RefObject<HTMLButtonElement> = useRef(null);
+
+    const filterThreads = () => {
+        chips.current?.classList.toggle('active');
+
+        //todo: filter threads
+    }
+
+
+    return (
+        <ChipsButton ref={chips} onClick={() => filterThreads()}>
+            {text}
+        </ChipsButton>
+    )
+}
+
+export default FilterChips;

--- a/frontend/src/components/Forum/Forum.tsx
+++ b/frontend/src/components/Forum/Forum.tsx
@@ -6,12 +6,15 @@ import { ForumThread } from "../../api";
 import {getMockThread, headers, classes, content} from "./mockData";
 import FilterChips from "./FilterChips/FilterChips";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {useNavigate} from "react-router-dom";
+import {PageRoutes} from "../../utils/constants";
 
 
 const Forum: React.FC<{}> = () => {
     let mockData = Array.from(Array(10).keys()).map(idx => getMockThread(idx));
     const [isFavourite, setFavourite] = useState(mockData.map(elem => elem.isFavourite));
     const searchInputRef: React.MutableRefObject<HTMLInputElement | null> = useRef(null);
+    const navigate = useNavigate();
 
     function toggleFavourite(idx: number){
         mockData[idx].isFavourite = !mockData[idx].isFavourite;
@@ -39,7 +42,8 @@ const Forum: React.FC<{}> = () => {
                             <ForumTile className={column.insideClass + " py-2 align-items-center d-flex"}>
                                 {colId === content(thread).length - 1 ? (
                                     <>
-                                        <OpenButton>Otwórz</OpenButton>
+                                        {/*TODO: navigation system - demo below*/}
+                                        <OpenButton onClick={() => navigate(PageRoutes.FORUM_THREAD + '/1')}>Otwórz</OpenButton>
                                         <Star icon = {faStarSolid}
                                               className={isFavourite[idx] ? 'starred': 'unstarred'}
                                               onClick={() => toggleFavourite(idx)}

--- a/frontend/src/components/Forum/Forum.tsx
+++ b/frontend/src/components/Forum/Forum.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
-import { Row } from "react-bootstrap";
-import { ForumHeader, ForumCol, ForumTile, ForumRow, OpenButton, Star, ForumContainer} from "./ForumStyles";
-import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
+import React, {useRef, useState} from 'react';
+import {Col, Row} from "react-bootstrap";
+import {ForumHeader, ForumCol, ForumTile, ForumRow, OpenButton, Star, ForumContainer, SearchBoxContainerModified, SearchBoxModified, AddThreadBtn} from "./ForumStyles";
+import {faMagnifyingGlass, faStar as faStarSolid} from '@fortawesome/free-solid-svg-icons';
 import { ForumThread } from "../../api";
 import {getMockThread, headers, classes, content} from "./mockData";
+import FilterChips from "./FilterChips/FilterChips";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 
 const Forum: React.FC<{}> = () => {
     let mockData = Array.from(Array(10).keys()).map(idx => getMockThread(idx));
     const [isFavourite, setFavourite] = useState(mockData.map(elem => elem.isFavourite));
-
+    const searchInputRef: React.MutableRefObject<HTMLInputElement | null> = useRef(null);
 
     function toggleFavourite(idx: number){
         mockData[idx].isFavourite = !mockData[idx].isFavourite;
@@ -56,6 +58,24 @@ const Forum: React.FC<{}> = () => {
 
     return (
         <ForumContainer>
+            <h2 className='text-center my-3'>Znajdź interesujący Cię temat w liście poniżej lub załóż nowy temat.</h2>
+            <Row className='px-2 my-5'>
+                <Col xs={2}>
+                    <FilterChips text="Tylko obserwowane"/>
+                </Col>
+                <Col xs={2}>
+                    <FilterChips text="Założone przez Ciebie"/>
+                </Col>
+                <Col xs={6}>
+                    <SearchBoxContainerModified onClick={() => searchInputRef.current?.focus()}>
+                        <FontAwesomeIcon icon={faMagnifyingGlass} fontSize={20} />
+                        <SearchBoxModified ref={searchInputRef} type="text" placeholder="Wyszukaj temat po nazwie" />
+                    </SearchBoxContainerModified>
+                </Col>
+                <Col xs={2}>
+                    <AddThreadBtn>Dodaj nowy temat</AddThreadBtn>
+                </Col>
+            </Row>
             <Row className="mt-5">
                     {getHeaderRow()}
                     {mockData.map((thread,idx) => getThread(thread, idx))}

--- a/frontend/src/components/Forum/Forum.tsx
+++ b/frontend/src/components/Forum/Forum.tsx
@@ -36,7 +36,7 @@ const Forum: React.FC<{}> = () => {
                 {content(thread).map((column, colId) => {
                     return (
                         <ForumCol key={colId} className={column.outsideClass}>
-                            <ForumTile className={column.insideClass}>
+                            <ForumTile className={column.insideClass + " py-2 align-items-center d-flex"}>
                                 {colId === content(thread).length - 1 ? (
                                     <>
                                         <OpenButton>Otwórz</OpenButton>
@@ -59,20 +59,20 @@ const Forum: React.FC<{}> = () => {
     return (
         <ForumContainer>
             <h2 className='text-center my-3'>Znajdź interesujący Cię temat w liście poniżej lub załóż nowy temat.</h2>
-            <Row className='px-2 my-5'>
-                <Col xs={2}>
+            <Row className='px-2 justify-content-center'>
+                <Col xxl={2} lg={4} className='my-2'>
                     <FilterChips text="Tylko obserwowane"/>
                 </Col>
-                <Col xs={2}>
+                <Col xxl={2} lg={4} className='my-2'>
                     <FilterChips text="Założone przez Ciebie"/>
                 </Col>
-                <Col xs={6}>
+                <Col xxl={6} lg={8} className='my-2'>
                     <SearchBoxContainerModified onClick={() => searchInputRef.current?.focus()}>
                         <FontAwesomeIcon icon={faMagnifyingGlass} fontSize={20} />
                         <SearchBoxModified ref={searchInputRef} type="text" placeholder="Wyszukaj temat po nazwie" />
                     </SearchBoxContainerModified>
                 </Col>
-                <Col xs={2}>
+                <Col xxl={2} lg={4} className='my-2'>
                     <AddThreadBtn>Dodaj nowy temat</AddThreadBtn>
                 </Col>
             </Row>

--- a/frontend/src/components/Forum/Forum.tsx
+++ b/frontend/src/components/Forum/Forum.tsx
@@ -2,51 +2,28 @@ import React, { useState } from 'react';
 import { Row } from "react-bootstrap";
 import { ForumHeader, ForumCol, ForumTile, ForumRow, OpenButton, Star, ForumContainer} from "./ForumStyles";
 import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
-import { ForumThread } from "../../api/models/forum-thread";
-import {User} from "../../api/models/user";
+import { ForumThread } from "../../api";
+import {getMockThread, headers, classes, content} from "./mockData";
+
 
 const Forum: React.FC<{}> = () => {
-    function getMockThread(idx: number){
-        let date: Date = new Date("2019-01-16"); 
-        let user: User = {
-            username: "username"+idx,
-            id: idx,
-            email: '',
-            userPlants: [],
-            forumPostList: [],
-            forumThreadList: []
-        };
-        let mockThread: ForumThread = {
-            id: idx,
-            title: "tytuł tematu " + idx,
-            creator: user,
-            isFavourite: false,
-            dateCreated: date,
-            forumPosts: []
-        };
-        return mockThread;
-    }
-    
-    const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel tematu', 'Data założenia tematu','Akcje'];
-    const classes = ['title','num','username','date','action'];
-
     let mockData = Array.from(Array(10).keys()).map(idx => getMockThread(idx));
-   
-    const COLS = Array.from(Array(headers.length).keys());
-
     const [isFavourite, setFavourite] = useState(mockData.map(elem => elem.isFavourite));
+
 
     function toggleFavourite(idx: number){
         mockData[idx].isFavourite = !mockData[idx].isFavourite;
         setFavourite(isFavourite.map((element, currIdx) => currIdx===idx ? !element : element));
-    };
+    }
 
     function getHeaderRow(){
         return(
             <ForumRow  className="m-0">
-                {COLS.map(idx => (<ForumCol key={idx} className={classes[idx]}>
-                                    <ForumHeader key={idx} className={classes[idx]}>{headers[idx]}</ForumHeader>
-                                </ForumCol>))}
+                {headers.map((header, idx) => (
+                    <ForumCol key={idx} className={classes[idx]}>
+                        <ForumHeader key={idx} className={classes[idx]}>{headers[idx]}</ForumHeader>
+                    </ForumCol>
+                ))}
             </ForumRow>
         )
     }
@@ -54,29 +31,25 @@ const Forum: React.FC<{}> = () => {
     function getThread(thread: ForumThread, idx: number){
         return(
             <ForumRow key={thread.id} className="m-0">
-                <ForumCol  className='title'>
-                    <ForumTile className='not-last'>{thread.title}</ForumTile>
-                </ForumCol>
-                <ForumCol  className='num'>
-                    <ForumTile className='not-last'>{thread.forumPosts.length}</ForumTile>
-                </ForumCol>
-                <ForumCol  className='username'>
-                    <ForumTile className='not-last'>{thread.creator.username}</ForumTile>
-                </ForumCol>
-                <ForumCol  className='date'>
-                    <ForumTile className='not-last'>
-                        {thread.dateCreated.getFullYear()+"-"+(thread.dateCreated.getMonth()+1)+"-"+thread.dateCreated.getDate()}
-                    </ForumTile>
-                </ForumCol>
-                <ForumCol  className='action'>
-                    <ForumTile>
-                        <OpenButton>Otwórz</OpenButton>
-                        <Star icon = {faStarSolid} 
-                            className={isFavourite[idx] ? 'starred': 'unstarred'} 
-                            onClick={() => toggleFavourite(idx)} 
-                        />
-                    </ForumTile>
-                </ForumCol>
+                {content(thread).map((column, colId) => {
+                    return (
+                        <ForumCol key={colId} className={column.outsideClass}>
+                            <ForumTile className={column.insideClass}>
+                                {colId === content(thread).length - 1 ? (
+                                    <>
+                                        <OpenButton>Otwórz</OpenButton>
+                                        <Star icon = {faStarSolid}
+                                              className={isFavourite[idx] ? 'starred': 'unstarred'}
+                                              onClick={() => toggleFavourite(idx)}
+                                        />
+                                    </>
+                                ) : (
+                                    <>{column.content}</>
+                                )}
+                            </ForumTile>
+                        </ForumCol>
+                    )
+                })}
             </ForumRow>
         )
     }

--- a/frontend/src/components/Forum/Forum.tsx
+++ b/frontend/src/components/Forum/Forum.tsx
@@ -3,11 +3,11 @@ import {Col, Row} from "react-bootstrap";
 import {ForumHeader, ForumCol, ForumTile, ForumRow, OpenButton, Star, ForumContainer, SearchBoxContainerModified, SearchBoxModified, AddThreadBtn} from "./ForumStyles";
 import {faMagnifyingGlass, faStar as faStarSolid} from '@fortawesome/free-solid-svg-icons';
 import { ForumThread } from "../../api";
-import {getMockThread, headers, classes, content} from "./mockData";
+import {getMockThread} from "./mockData";
 import FilterChips from "./FilterChips/FilterChips";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {useNavigate} from "react-router-dom";
-import {PageRoutes} from "../../utils/constants";
+import {PageRoutes, headers, classes, content} from "../../utils/constants";
 
 
 const Forum: React.FC<{}> = () => {
@@ -39,7 +39,7 @@ const Forum: React.FC<{}> = () => {
                 {content(thread).map((column, colId) => {
                     return (
                         <ForumCol key={colId} className={column.outsideClass}>
-                            <ForumTile className={column.insideClass + " py-2 align-items-center d-flex"}>
+                            <ForumTile className={"not-last py-2 align-items-center d-flex"}>
                                 {colId === content(thread).length - 1 ? (
                                     <>
                                         {/*TODO: navigation system - demo below*/}

--- a/frontend/src/components/Forum/ForumStyles.tsx
+++ b/frontend/src/components/Forum/ForumStyles.tsx
@@ -45,21 +45,41 @@ export const ForumCol =  styled(Col)`
     min-width: 0;
 
     &.title{
-      max-width: 35%;
+      max-width: 30%;
     }
-    &.num{
+    &.num {
+      min-width: 10%;
       max-width: 15%;
     }
     &.username{
       max-width: 20%;
     }
     &.date{
-      max-width: 20%;
+      max-width: 15%;
     }
     &.action{
-      max-width: 10%;
+      max-width: 20%;
     }
 
+    /* There is not enough space in mobile mode to display so much data in one line. 
+       That's why I decided to turn off the visibility of some columns. */
+    @media (max-width: 550px) {
+      &.title{
+        max-width: 60%;
+      }
+      &.num {
+        display: none;
+      }
+      &.username{
+        display: none;
+      }
+      &.date{
+        display: none;
+      }
+      &.action{
+        max-width: 40%;
+      }
+    }
 `;
 
 export const ForumRow = styled(Row)`
@@ -108,6 +128,13 @@ export const ForumContainer = styled.div`
   justify-content: center;
   margin-right: 6px;
   margin-left: 6px;
+  
+  @media(max-width: 768px){
+    left: 0;
+    width: 100vw;
+    padding-right: 10px;
+    padding-bottom: 100px;
+  }
 `;
 
 export const SearchBoxContainerModified = styled(SearchBoxContainer)`

--- a/frontend/src/components/Forum/ForumStyles.tsx
+++ b/frontend/src/components/Forum/ForumStyles.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Col, Row } from "react-bootstrap";
 import styled from "styled-components";
+import {SearchBox, SearchBoxContainer} from "../PlantsView/PlantsViewStyles";
 
 
 export const Star = styled(FontAwesomeIcon)`
@@ -107,4 +108,24 @@ export const ForumContainer = styled.div`
   justify-content: center;
   margin-right: 6px;
   margin-left: 6px;
+`;
+
+export const SearchBoxContainerModified = styled(SearchBoxContainer)`
+  height: 40px;
+  font-size: 17px;
+`;
+
+export const SearchBoxModified = styled(SearchBox)`
+  height: 40px;
+`;
+
+export const AddThreadBtn = styled.button`
+  border-radius: 10px;
+  background-color: #008F8C;
+  height: 40px;
+  width: 100%;
+  font-size: 17px;
+  color: white;
+  border: none;
+  outline: none;
 `;

--- a/frontend/src/components/Forum/mockData.tsx
+++ b/frontend/src/components/Forum/mockData.tsx
@@ -1,36 +1,5 @@
 import {ForumThread, User} from "../../api";
 
-const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel', 'Data założenia','Akcje'];
-const classes = ['title', 'num', 'username', 'date', 'action'];
-
-const content = (thread: ForumThread) => [
-    {
-        outsideClass: classes[0],
-        insideClass: 'not-last',
-        content: thread.title
-    },
-    {
-        outsideClass: classes[1],
-        insideClass: 'not-last',
-        content: thread.forumPosts.length
-    },
-    {
-        outsideClass: classes[2],
-        insideClass: 'not-last',
-        content: thread.creator.username
-    },
-    {
-        outsideClass: classes[3],
-        insideClass: 'not-last',
-        content: thread.dateCreated.getFullYear()+"-"+(thread.dateCreated.getMonth()+1)+"-"+thread.dateCreated.getDate()
-    },
-    {
-        outsideClass: classes[4],
-        insideClass: 'not-last',
-        content: null
-    }
-]
-
 export function getMockThread(idx: number){
     let date: Date = new Date("2019-01-16");
     let user: User = {
@@ -52,4 +21,3 @@ export function getMockThread(idx: number){
     return mockThread;
 }
 
-export {headers, classes, content}

--- a/frontend/src/components/Forum/mockData.tsx
+++ b/frontend/src/components/Forum/mockData.tsx
@@ -1,6 +1,6 @@
 import {ForumThread, User} from "../../api";
 
-const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel tematu', 'Data założenia tematu','Akcje'];
+const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel', 'Data założenia','Akcje'];
 const classes = ['title', 'num', 'username', 'date', 'action'];
 
 const content = (thread: ForumThread) => [

--- a/frontend/src/components/Forum/mockData.tsx
+++ b/frontend/src/components/Forum/mockData.tsx
@@ -1,5 +1,4 @@
 import {ForumThread, User} from "../../api";
-import React from "react";
 
 const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel tematu', 'Data założenia tematu','Akcje'];
 const classes = ['title', 'num', 'username', 'date', 'action'];

--- a/frontend/src/components/Forum/mockData.tsx
+++ b/frontend/src/components/Forum/mockData.tsx
@@ -1,0 +1,56 @@
+import {ForumThread, User} from "../../api";
+import React from "react";
+
+const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel tematu', 'Data założenia tematu','Akcje'];
+const classes = ['title', 'num', 'username', 'date', 'action'];
+
+const content = (thread: ForumThread) => [
+    {
+        outsideClass: classes[0],
+        insideClass: 'not-last',
+        content: thread.title
+    },
+    {
+        outsideClass: classes[1],
+        insideClass: 'not-last',
+        content: thread.forumPosts.length
+    },
+    {
+        outsideClass: classes[2],
+        insideClass: 'not-last',
+        content: thread.creator.username
+    },
+    {
+        outsideClass: classes[3],
+        insideClass: 'not-last',
+        content: thread.dateCreated.getFullYear()+"-"+(thread.dateCreated.getMonth()+1)+"-"+thread.dateCreated.getDate()
+    },
+    {
+        outsideClass: classes[4],
+        insideClass: 'not-last',
+        content: null
+    }
+]
+
+export function getMockThread(idx: number){
+    let date: Date = new Date("2019-01-16");
+    let user: User = {
+        username: "username"+idx,
+        id: idx,
+        email: '',
+        userPlants: [],
+        forumPostList: [],
+        forumThreadList: []
+    };
+    let mockThread: ForumThread = {
+        id: idx,
+        title: "tytuł tematu " + idx,
+        creator: user,
+        isFavourite: false,
+        dateCreated: date,
+        forumPosts: []
+    };
+    return mockThread;
+}
+
+export {headers, classes, content}

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import {ForumThread} from "../api";
+
 export const PageRoutes = {
     LOGIN: '/home',
     DASHBOARD: '/dashboard',
@@ -7,3 +9,31 @@ export const PageRoutes = {
     SETTINGS: '/settings',
     FORUM_THREAD: '/forum/thread'
 };
+
+const headers = ['Tytuł tematu', 'Liczba odpowiedzi', 'Założyciel', 'Data założenia','Akcje'];
+const classes = ['title', 'num', 'username', 'date', 'action'];
+
+const content = (thread: ForumThread) => [
+    {
+        outsideClass: classes[0],
+        content: thread.title
+    },
+    {
+        outsideClass: classes[1],
+        content: thread.forumPosts.length
+    },
+    {
+        outsideClass: classes[2],
+        content: thread.creator.username
+    },
+    {
+        outsideClass: classes[3],
+        content: thread.dateCreated.getFullYear()+"-"+(thread.dateCreated.getMonth()+1)+"-"+thread.dateCreated.getDate()
+    },
+    {
+        outsideClass: classes[4],
+        content: null
+    }
+]
+
+export {headers, classes, content}


### PR DESCRIPTION
Dodanie chipsów filtrujących, wyszukiwarki i przycisku do dodawania wątku. Dodanie responsywności.

Uwaga: W trybie mobilnym jest za mało miejsca żeby wyświetlić tak dużo danych w jednym wierszu tabeli. Dlatego zdecydowałem się wyłączyć widoczność niektórych kolumn. 